### PR TITLE
目標削除機能を実装 #33

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -13,6 +13,15 @@ class Api::TasksController < ApplicationController
     end
   end
 
+  def destroy
+    @task = Task.find(params[:id])
+    if @task.destroy
+      render :index, status: :ok
+    else
+      render json: @task.errors, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def task_params

--- a/app/javascript/packs/components/task_index.vue
+++ b/app/javascript/packs/components/task_index.vue
@@ -15,6 +15,7 @@
           <td>{{ task.goal }}</td>
           <td>
             <router-link to="/task/edit">edit</router-link>
+            <button @click="deleteTask(task.id)">削除</button>
           </td>
         </tr>
       </tbody>
@@ -45,6 +46,15 @@
           console.log(error);
         });
       },
+      deleteTask: function (task_id) {
+        const params = { id: task_id }
+        axios.delete('/api/tasks/' + task_id, { params: params }).then((response) => {
+          console.log('削除完了')
+          location.reload();
+        }, (error) => {
+          console.log(error);
+        })
+      }
     }
   }
 </script>

--- a/app/javascript/packs/components/task_new.vue
+++ b/app/javascript/packs/components/task_new.vue
@@ -14,6 +14,7 @@
         <button v-on:click="createTask">新規作成</button>
       </div>
     </div>
+    <router-link to="/tasks">目標設定画面</router-link>
     <router-link to="/">マイページ</router-link>
   </div>
 </template>

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :user
-  has_many :action_records
+  has_many :action_records, dependent: :destroy
 
   validates :task, presence: true
   validates :goal, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :tasks
-  has_many :action_records
+  has_many :tasks, dependent: :destroy
+  has_many :action_records, dependent: :destroy
 end

--- a/app/views/api/tasks/show.json.jbuilder
+++ b/app/views/api/tasks/show.json.jbuilder
@@ -1,0 +1,3 @@
+json.set! :task do
+  json.extract! @task, :id, :name, :is_done, :created_at, :updated_at
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
   web:
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    stdin_open: true
+    tty: true
     volumes:
       - .:/records-management-gamefiction
     ports:


### PR DESCRIPTION
Closes #33 

 - 目標削除機能を実装
   - tasks_controllerにdestroyアクションを作成
   - task_indexに削除ボタンを実装
   - 新規目標作成画面に目標設定画面へのリンクを追加
   - show.json.jbuilderを作成
   - docker-compose.ymlにbinding.pry用の設定を追加