### PR TITLE
action_recordsコントローラをapi化 #36

### DIFF
--- a/app/controllers/action_records_controller.rb
+++ b/app/controllers/action_records_controller.rb
@@ -1,2 +1,0 @@
-class ActionRecordsController < ApplicationController
-end

--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -1,0 +1,9 @@
+class Api::ActionRecordsController < ApplicationController
+  def index
+    @action_records = ActionRecord.all
+  end
+
+  def show
+    @action_record = ActionRecord.find(params[:id])
+  end
+end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -23,7 +23,6 @@ class Api::TasksController < ApplicationController
 
   def update
     @task = Task.find(params[:id])
-    puts "-------update---------"
 
     if @task.update(task_params)
       render :show, status: :ok

--- a/app/views/api/action_records/index.json.jbuilder
+++ b/app/views/api/action_records/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.set! :action_records do
+  json.array! @action_records do |action_record|
+    json.extract! action_record, :id, :action_day, :action,
+                  :action_experience_point,
+                  :user_id, :task_id, :created_at,
+                  :updated_at
+  end
+end

--- a/app/views/api/action_records/show.json.jbuilder
+++ b/app/views/api/action_records/show.json.jbuilder
@@ -1,0 +1,6 @@
+json.set! :action_record do
+  json.extract! @action_record, :id, :action_day, :action,
+                :action_experience_point,
+                :user_id, :task_id, :created_at,
+                :updated_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,13 @@
 Rails.application.routes.draw do
-  devise_for :users
-
   root to: "home#index"
   get "/tasks", to: "home#index"
   get "/task/new", to: "home#index"
   get "/task/:id/edit", to: "home#index"
 
+  devise_for :users
+
   namespace :api, format: "json" do
     resources :tasks
+    resources :action_records
   end
 end


### PR DESCRIPTION
Closes #36 

 - action_records_controller.rbをcontroller/api配下に移動
 - action_records_controllerをApi化
 - router.rbでapi配下にルーティングを設定
 - view/action_recordsフォルダをview/api配下に移動
 - データの受け渡し用にview/api/action_recordsフォルダにindex.json.jbuilerとshow.json.jbuilderを作成
 - task_controller.rbのputs文を削除