### PR TITLE
行動記録の新規登録機能を実装 #40

### DIFF
--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -6,4 +6,25 @@ class Api::ActionRecordsController < ApplicationController
   def show
     @action_record = ActionRecord.find(params[:id])
   end
+
+  def new
+    @action_record = ActionRecord.new
+  end
+
+  def create
+    @action_record = ActionRecord.new(action_record_params)
+
+    if @action_record.save
+      render :index, status: :created
+    else
+      render json: @action_record.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def action_record_params
+    params.fetch(:action_record, {}).permit(:action_day, :action,
+                                            :action_experience_point, :user_id, :task_id)
+  end
 end

--- a/app/javascript/packs/components/action_records_index.vue
+++ b/app/javascript/packs/components/action_records_index.vue
@@ -18,11 +18,10 @@
       </div>
       <div>
         <label id="action">実績</label>
-        <input type="text" id="action" v-bind:value="action">
+        <input type="text" id="action" v-model="action">
       </div>
-      <button>送信</button>
+      <button @click="createActionRecord">登録</button>
     </div>
-    <router-link to="/action-records/new">new</router-link>
     <router-link to="/">マイページ</router-link>
   </div>
 </template>
@@ -87,6 +86,8 @@
         this.searchAction();
       },
       searchAction: function () {
+        this.action = ''
+
         for (var i = 0; i < this.action_records.length; i++) {
           if (this.action_records[i].action_day == this.action_day
               && this.action_records[i].task_id == this.selectTask) {
@@ -94,10 +95,12 @@
           }
         }
       },
-      editLink: function (task_id) {
-        this.$router.push({
-          name: 'task-edit',
-          params: { id: task_id }
+      createActionRecord: function () {
+        axios.post('/api/action_records', { action_record: { action_day: this.action_day, action: Number(this.action), 
+        action_experience_point: 7, user_id: 3, task_id: this.selectTask } }).then((response) => {
+          alert('登録しました')
+        }, (error) => {
+          console.log(error)
         })
       }
     }


### PR DESCRIPTION
Closes #40 

 - 行動記録の新規登録機能を実装
   - action_records.controller.rbにnew,createアクションとaction_record_paramsメソッドを追加
   - action_record_index.vueに新規登録用の処理を追加