### PR TITLE
action_recordsテーブルに一意制約を追加 #44

### DIFF
--- a/app/models/action_record.rb
+++ b/app/models/action_record.rb
@@ -4,4 +4,6 @@ class ActionRecord < ApplicationRecord
 
   validates :action_day, presence: true
   validates :action, presence: true
+
+  validates :action_day, uniqueness: { scope: :task_id }
 end

--- a/db/migrate/20210210050909_add_index_action_records_action_day.rb
+++ b/db/migrate/20210210050909_add_index_action_records_action_day.rb
@@ -1,0 +1,5 @@
+class AddIndexActionRecordsActionDay < ActiveRecord::Migration[6.1]
+  def change
+    add_index :action_records, [:action_day, :task_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_06_094103) do
+ActiveRecord::Schema.define(version: 2021_02_10_050909) do
 
   create_table "action_records", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "action_day", null: false
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2021_02_06_094103) do
     t.integer "task_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["action_day", "task_id"], name: "index_action_records_on_action_day_and_task_id", unique: true
     t.index ["task_id"], name: "index_action_records_on_task_id"
     t.index ["user_id"], name: "index_action_records_on_user_id"
   end


### PR DESCRIPTION
Closes #44 

 - action_dayとtask_idの組み合わせの一意制約を追加
   - action_record.rbにaction_dayとtask_idの組み合わせの一意制約を追加
   - axtion_recordsテーブルにaction_dayとtask_idの組み合わせの一意制約を追加