### PR TITLE
ログイン中のユーザのaction_recordsを取得 #57

### DIFF
--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -3,6 +3,8 @@ class Api::ActionRecordsController < ApplicationController
 
   def index
     @action_records = ActionRecord.all
+    # ログイン中のユーザのアクションレコードを取得
+    #@action_records = current_user.action_records
   end
 
   def show

--- a/app/javascript/packs/components/action_records_index.vue
+++ b/app/javascript/packs/components/action_records_index.vue
@@ -90,14 +90,15 @@
 
         for (var i = 0; i < this.action_records.length; i++) {
           if (this.action_records[i].action_day == this.action_day
-              && this.action_records[i].task_id == this.selectTask) {
+              && this.action_records[i].task_id == this.selectTask
+              && this.action_records[i].user_id == localStorage.getItem('user_id')) {
             this.action = this.action_records[i].action
           }
         }
       },
       createActionRecord: function () {
         axios.post('/api/action_records/createOrUpdate', { action_record: { action_day: this.action_day, action: Number(this.action), 
-        action_experience_point: 7, user_id: 3, task_id: this.selectTask } }).then((response) => {
+        action_experience_point: 7, user_id: localStorage.getItem('user_id'), task_id: this.selectTask } }).then((response) => {
           alert('登録しました')
         }, (error) => {
           console.log(error)


### PR DESCRIPTION
Closes #57 

- ログイン中のユーザのaction_recordsを取得 
  - action_records_controller.rbのindexアクションでログイン中のユーザのaction_recordsを取得するように修正
  - action_recordを新規登録する際にログイン時にローカルストレージに保存したユーザIDを使うように修正