### PR TITLE
action_record,user,user_levelモデルにバリデーションを追加 #70

### DIFF
--- a/app/models/action_record.rb
+++ b/app/models/action_record.rb
@@ -4,8 +4,8 @@ class ActionRecord < ApplicationRecord
 
   validates :action_day, presence: true
   validates :action, presence: true
-
-  validates :action_day, uniqueness: { scope: :task_id }
+  validates :action_experience_point, presence: true
+  validates :action_day, uniqueness: { scope: [:task_id, :user_id] }
 
   # 実績の経験値を取得
   def getActionExperiencePoint(action_day, task_id, user_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,7 @@ class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
   has_many :action_records, dependent: :destroy
   has_many :user_levels
+
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
 end

--- a/app/models/user_level.rb
+++ b/app/models/user_level.rb
@@ -1,6 +1,9 @@
 class UserLevel < ApplicationRecord
   belongs_to :user
 
+  validates :level, presence: true
+  validates :total_experience_point, presence: true
+
   # ユーザのレベルを取得
   def getUserLevel(user_id)
     UserLevel.find_by(user_id: user_id).level


### PR DESCRIPTION
Closes #70 

- 各モデルにバリデーションを追加
  - action_recordモデルにaction_experience_pointのnull制約を追加
  - action_recordモデルにaction_dayとtask_idとuser_idの一意制約を追加
  - userモデルにnameのnull制約を追加
  - userモデルにemailのnull制約と正規表現を追加
  - user_levelモデルのlevelにnull制約を追加
  - user_levelモデルのtotal_experience_pointにnull制約を追加