### PR TITLE
ユーザ新規登録時にuser_levelsテーブルに新規登録する処理を実装 #74

### DIFF
--- a/app/controllers/api/user_levels_controller.rb
+++ b/app/controllers/api/user_levels_controller.rb
@@ -1,0 +1,16 @@
+class Api::UserLevelsController < ApplicationController
+  def create
+    @user_level = UserLevel.new(user_levels_params)
+
+    if @user_level.save
+    else
+      render json: @user_level.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_levels_params
+    params.require(:user_level).permit(:level, :total_experience_point, :user_id)
+  end
+end

--- a/app/javascript/packs/components/sinup.vue
+++ b/app/javascript/packs/components/sinup.vue
@@ -1,33 +1,35 @@
 <template>
 <div>
     <h1>新規登録画面</h1>
-    <div>
-      <label for="name">
-        Name
-      </label>
-      <input v-model="user.name" id="name" type="text" placeholder="name">
-    </div>
-    <div>
-      <label for="email">
-        Email
-      </label>
-      <input v-model="user.email" id="Email" type="text" placeholder="email">
-    </div>
-    <div>
-      <label for="password">
-        Password
-      </label>
-      <input v-model="user.password" id="password" type="password" placeholder="password">
-    </div>
-    <div>
-      <label for="password">
-        Password(確認用)
-      </label>
-      <input v-model="user.password_confirmation" id="password_confirmation" type="password" placeholder="password_confirmation">
-    </div>
-    <button @click="registerUser">
-      Sign Up
-    </button>
+    <form>
+      <div>
+        <label for="name">
+          ユーザ名
+        </label>
+        <input v-model="user.name" id="name" type="text" placeholder="name">
+      </div>
+      <div>
+        <label for="email">
+          メールアドレス
+        </label>
+        <input v-model="user.email" id="Email" type="text" placeholder="email">
+      </div>
+      <div>
+        <label for="password">
+          パスワード
+        </label>
+        <input v-model="user.password" id="password" type="password" placeholder="password">
+      </div>
+      <div>
+        <label for="password">
+          パスワード(確認用)
+        </label>
+        <input v-model="user.password_confirmation" id="password_confirmation" type="password" placeholder="password_confirmation">
+      </div>
+      <button @click="registerUser">
+        Sign Up
+      </button>
+    </form>
   </div>
 </template>
 
@@ -56,8 +58,18 @@
           localStorage.setItem('user_id', response.data['data'].id)
           localStorage.setItem('email', response.data['data'].email)
           localStorage.setItem('name', response.data['data'].name)
-          location.href = "http://localhost:3000/mypage"
-          return response
+          console.log('ログイン完了')
+          // user_levelsテーブルに新規作成したユーザの情報を作成
+          axios.post('api/user_levels', { level: 1, total_experience_point: 0, 
+                                          user_id: localStorage.getItem('user_id') 
+                                        }).then((response) => {
+            console.log('user_levelsテーブルに新規作成完了')
+          }, (error) => {
+            console.log('失敗')
+            console.log(error)
+          })
+          //location.href = "http://localhost:3000/mypage"
+          // return response
         }, (error) => {
           console.log(error)
         })

--- a/app/javascript/packs/components/sinup.vue
+++ b/app/javascript/packs/components/sinup.vue
@@ -58,18 +58,15 @@
           localStorage.setItem('user_id', response.data['data'].id)
           localStorage.setItem('email', response.data['data'].email)
           localStorage.setItem('name', response.data['data'].name)
-          console.log('ログイン完了')
-          // user_levelsテーブルに新規作成したユーザの情報を作成
           axios.post('api/user_levels', { level: 1, total_experience_point: 0, 
                                           user_id: localStorage.getItem('user_id') 
                                         }).then((response) => {
-            console.log('user_levelsテーブルに新規作成完了')
           }, (error) => {
             console.log('失敗')
             console.log(error)
           })
-          //location.href = "http://localhost:3000/mypage"
-          // return response
+          location.href = "http://localhost:3000/mypage"
+          return response
         }, (error) => {
           console.log(error)
         })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,5 +25,6 @@ Rails.application.routes.draw do
       get "actionRecordReferences", :on => :collection
       post "createOrUpdate", :on => :collection
     end
+    resource :user_levels, only: [:create]
   end
 end

--- a/spec/requests/api/user_levels_request_spec.rb
+++ b/spec/requests/api/user_levels_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Api::UserLevels", type: :request do
+
+end


### PR DESCRIPTION
Closes #74 

- ユーザ新規登録時にuser_levelsテーブルに新規登録する処理を実装
  - user_levelsコントローラを新規作成
  - user_levelsコントローラにcreateアクションを作成
  - routes.rbにuser_levelsのapi用のrouteを新規作成
  - signup.vueにユーザの新規登録成功時にuser_levelsテーブルに新規登録する処理を実装
  - 