### PR TITLE
目標と実績の少数のデータに対応する実装 #78

### DIFF
--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -26,9 +26,6 @@ class Api::ActionRecordsController < ApplicationController
         # レベル処理を行う
         levelup_data = levelUpAndDown(action_record_params[:task_id], action_record_params[:action_day], action_record_params[:action])
 
-        puts "levelup_data"
-        puts levelup_data
-
         render :show, status: :created
       else
         render json: @action_record.errors, status: :unprocessable_entity
@@ -37,9 +34,6 @@ class Api::ActionRecordsController < ApplicationController
       if @action_record.update(action_record_params)
         # レベル処理を行う
         levelup_data = levelUpAndDown(action_record_params[:task_id], action_record_params[:action_day], action_record_params[:action])
-
-        puts "levelup_data"
-        puts levelup_data
 
         render :show, status: :ok
       else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,10 +50,8 @@ class ApplicationController < ActionController::Base
 
       # 今回の追加分の前に目標を達成しているかチェック
       if ((week_of_action - action) < goal)
-        puts "今回の追加分までに目標未達成"
         #今回の追加分を含めた場合に目標を達成しているかチェック
         if (week_of_action >= goal)
-          puts "今回の追加分で目標達成!"
           # 目標達成で経験値を追加
           point = action_experience_point + 100
         end
@@ -63,10 +61,9 @@ class ApplicationController < ActionController::Base
       total_experience_point += point
 
       # 総経験値が次レベルの必要経験値を上回ってる場合は処理に入る
-      if (total_experience_point >= next_level_required_experience_point) 
+      if (total_experience_point >= next_level_required_experience_point)
         # 総経験値が次レベルの必要経験値を下回るまでレベルアップする
         while total_experience_point >= next_level_required_experience_point
-          puts "レベルアップ"
           level += 1
           next_level_required_experience_point = level_info.getRequreidExperiecePoint(level + 1)
         end
@@ -99,22 +96,19 @@ class ApplicationController < ActionController::Base
         total_experience_point += point
 
         # 現在の総経験値が次のレベルの必要経験値を上回っているかチェック
-        if (total_experience_point >= next_level_required_experience_point)  
+        if (total_experience_point >= next_level_required_experience_point)
           # 上回っている場合、総経験値が次のレベルの必要経験値を下回るまでレベルアップ処理を繰り返す
           while total_experience_point >= next_level_required_experience_point
-            puts "レベルアップ"
             level += 1
-            puts "level"
-            puts level
             next_level_required_experience_point = level_info.getRequreidExperiecePoint(level + 1)
           end
-          
+
           # ユーザのレベルアップ処理後にレベルを登録
           user_level.uploadUserLevel(current_user.id, level)
         end
       else
         # 修正によりactionが減少した場合
-        
+
         # 差分と目標から減少する経験値を計算
         point = action_record.culcurateExperiencePoint(difference, goal)
         # 実績の経験値を取得
@@ -136,8 +130,7 @@ class ApplicationController < ActionController::Base
         # 今回の減少分を含めた総経験値が現在のレベルの必要経験値を割っていないかチェック
         if (total_experience_point < current_level_required_experience_point)
           # 必要経験値を割っている場合はレベルダウン後の必要経験値を割らなくなるまでレベルダウンを繰り返す
-          while total_experience_point >=  current_level_required_experience_point
-            puts "レベルダウン"
+          while total_experience_point >= current_level_required_experience_point
             level -= 1
             current_level_required_experience_point = level_info.getRequreidExperiecePoint(level)
           end

--- a/app/javascript/packs/components/action_records_index.vue
+++ b/app/javascript/packs/components/action_records_index.vue
@@ -112,7 +112,8 @@
         }
       },
       culculateActionExperiencePoint: function () {
-        this.action_experience_point = this.action / this.goal * 100
+        // 目標と実績が少数点第２位まで対応
+        this.action_experience_point = (Math.round(this.action * 100) / 100) / (Math.round(this.goal * 100) / 100) * 100
       },
       createActionRecord: function () {
         this.culculateActionExperiencePoint();

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -2,8 +2,6 @@ class Level < ApplicationRecord
 
   # 指定したレベルの必要経験値を取得
   def getRequreidExperiecePoint(level)
-    puts "getRequreidExperiecePoint"
-    puts level
     Level.find_by(level: level).required_experience_point
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
 
   has_many :tasks, dependent: :destroy
   has_many :action_records, dependent: :destroy
-  has_many :user_levels
+  has_many :user_levels, dependent: :destroy
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }

--- a/db/migrate/20210220100903_change_data_action_toaction_records.rb
+++ b/db/migrate/20210220100903_change_data_action_toaction_records.rb
@@ -1,0 +1,5 @@
+class ChangeDataActionToactionRecords < ActiveRecord::Migration[6.1]
+  def change
+    change_column :action_records, :action, :float
+  end
+end

--- a/db/migrate/20210220101054_change_data_goal_to_tasks.rb
+++ b/db/migrate/20210220101054_change_data_goal_to_tasks.rb
@@ -1,0 +1,5 @@
+class ChangeDataGoalToTasks < ActiveRecord::Migration[6.1]
+  def change
+    change_column :tasks, :goal, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_19_135742) do
+ActiveRecord::Schema.define(version: 2021_02_20_101054) do
 
   create_table "action_records", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "action_day", null: false
-    t.integer "action", null: false
+    t.float "action", null: false
     t.integer "action_experience_point", default: 0, null: false
     t.bigint "user_id", null: false
     t.integer "task_id", null: false
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_135742) do
 
   create_table "tasks", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "task", null: false
-    t.integer "goal", null: false
+    t.float "goal", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,6 +2,8 @@ puts "テストデータ削除"
 User.destroy_all
 Task.destroy_all
 ActionRecord.destroy_all
+UserLevel.destroy_all
+Level.destroy_all
 
 puts "テストデータ投入"
 
@@ -18,12 +20,15 @@ UserLevel.create!(level: 1, total_experience_point: 10, user_id: user2.id)
 
 puts "user_levelsテーブルにデータ投入完了"
 
-Level.create!(level: 1, required_experience_point: 10)
+Level.create!(level: 1, required_experience_point: 0)
 Level.create!(level: 2, required_experience_point: 100)
 Level.create!(level: 3, required_experience_point: 200)
 Level.create!(level: 4, required_experience_point: 300)
 Level.create!(level: 5, required_experience_point: 400)
 Level.create!(level: 6, required_experience_point: 500)
+Level.create!(level: 7, required_experience_point: 600)
+Level.create!(level: 8, required_experience_point: 700)
+Level.create!(level: 9, required_experience_point: 800)
 
 Task.create!(task: "test1", goal: 1, user_id: user1.id)
 Task.create!(task: "test2", goal: 10, user_id: user1.id)


### PR DESCRIPTION
Closes #78 

- DBを修正
  - tasksテーブルのgoalカラムをintegerからfloatへ修正
  - action_recordsテーブルのactionをintegerからfloatへ修正

- 行動記録画面の経験値の計算処理を修正
  - 目標と実績が少数の場合でも経験値の処理が正常に動くように修正
  - 少数第２位まで対応しているがそれ以降に関しては未対応
 
- モデル間の依存関係を修正
  - userモデルを削除した際にuser_levelモデルも削除されるように修正

- テストデータの追加
  - levelsテーブルのテストデータを追加

- リファクタリング
  - action_records_controller、application_controller、user_levelsモデルの処理確認用のput処理を削除