### PR TITLE
マイページに1週間の合計実績を表示するよう実装 #98

### DIFF
--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -66,13 +66,6 @@ class Api::ActionRecordsController < ApplicationController
       to = Time.now.next_month.beginning_of_month
     end
 
-    puts "today"
-    puts today
-    puts "from"
-    puts from
-    puts "to"
-    puts to
-
     # ユーザのtask_idを配列に入れる
     tasks_ids = current_user.tasks.ids
 

--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -45,6 +45,13 @@ class Api::ActionRecordsController < ApplicationController
 
     # form...toの場合、toの日付は含まれないため指定する範囲の翌日をtoに指定する
     case interval
+    when "thisWeek"
+      action_record = ActionRecord.new
+      today = Time.now
+      day_of_week = action_record.getDayOfTheWeek(today)
+      range_of_week = action_record.getWeekRange(today, day_of_week)
+      from = range_of_week[0]
+      to = range_of_week[1]
     when "thisMonth"
       from = Time.now.beginning_of_month
       to = Time.now.next_month.beginning_of_month
@@ -58,6 +65,13 @@ class Api::ActionRecordsController < ApplicationController
       from = Time.now.ago(6.month).beginning_of_month
       to = Time.now.next_month.beginning_of_month
     end
+
+    puts "today"
+    puts today
+    puts "from"
+    puts from
+    puts "to"
+    puts to
 
     # ユーザのtask_idを配列に入れる
     tasks_ids = current_user.tasks.ids
@@ -76,7 +90,7 @@ class Api::ActionRecordsController < ApplicationController
       days = Date.parse(to.to_s) - Date.parse(from.to_s)
 
       # 期間内の目標の合計値を変数に代入
-      total_goal = Task.find(id).goal * days.to_i
+      total_goal = (Task.find(id).goal * days.to_i / 7).floor(1).to_f
 
       # 期間内の実績の合計値を変数に代入
       total_actions = ActionRecord.where(task_id: id)

--- a/app/javascript/packs/components/mypage.vue
+++ b/app/javascript/packs/components/mypage.vue
@@ -17,16 +17,16 @@
                   <tr>
                     <th scope="col">タスク名</th>
                     <th scope="col">1週間の目標</th>
-                    <th scope="col"></th>
+                    <th scope="col">1週間の実績</th>
+                    <th scope="col">達成率(%)</th>
                 </tr>
                 </thead>
                 <tbody>
-                  <tr v-for="task in tasks" v-bind:key="task.id" scope="row">
-                    <td>{{ task.task }}</td>
-                    <td>{{ task.goal }}</td>
-                    <td>
-                      <button class="btn btn-primary" @click="editLink(task.id)">修正</button>
-                    </td>
+                  <tr v-for="reference_data in references_data" :key="reference_data.id" scope="row">
+                    <td>{{ reference_data.task }}</td>
+                    <td>{{ reference_data.total_goal }}</td>
+                    <td>{{ reference_data.total_action }}</td>
+                    <td>{{ reference_data.achievement_rate }}</td>
                   </tr>
                 </tbody>
               </table>
@@ -51,38 +51,37 @@
       return {
         name: localStorage.getItem('name'),
         level: '',
-        tasks: [],
+        references_data: [],
+        headers: {
+                  'access-token': localStorage.getItem('access-token'),
+                  uid: localStorage.getItem('uid'),
+                  client: localStorage.getItem('client') 
+                },
       }
     },
     mounted: function () {
-      this.fetchTasks();
+      this.fetchReferencesData();
       this.fetchUserLevel();
     },
     methods: {
-      fetchTasks: function () {
-        axios.get('/api/tasks', 
-                  { headers: {
-                    'access-token': localStorage.getItem('access-token'),
-                    uid: localStorage.getItem('uid'),
-                    client: localStorage.getItem('client') 
-                    }
+      fetchReferencesData: function () {
+        axios.get('/api/action_records/actionRecordReferences', 
+                  { params: { interval: "thisWeek" },
+                    headers: this.headers
                   }
-        ).then((response) => {
-          for(var i = 0; i < response.data.tasks.length; i++) {
-            this.tasks.push(response.data.tasks[i]);
-          }
-        }, (error) => {
-          console.log(error);
-        });
+      ).then((response) => {
+        this.references_data.splice(0)
+        for(var i = 0; i <response.data.references_data.length; i++) {
+            this.references_data.push(response.data.references_data[i]);
+        }
+      }, (error) => {
+        console.log(error);
+      });
       },
       fetchUserLevel: function () {
         axios.get('/api/user_levels',
                   { params: { user_id: localStorage.getItem('user_id') },
-                    headers: {
-                    'access-token': localStorage.getItem('access-token'),
-                    uid: localStorage.getItem('uid'),
-                    client: localStorage.getItem('client') 
-                    }
+                    headers: this.headers
                   }
         ).then((response) => {
           this.level = response.data.user_level.level


### PR DESCRIPTION
Closes #98 

- マイページに1週間の合計実績を表示するよう実装 
  - action_records_controllerのデータ参照用のメソッドに今週の場合の処理を追加
  - mypage.vueでタスク一覧を取得する際にaction_records_controllerのactionRecordReferencesを参照するように修正

