### PR TITLE
tasksテーブルに目標の単位を追加し、各ページで単位を表示するように修正 #116

### DIFF
--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -85,6 +85,9 @@ class Api::ActionRecordsController < ApplicationController
       # 期間内の目標の合計値を変数に代入
       total_goal = (Task.find(id).goal * days.to_i / 7).floor(1).to_f
 
+      # 目標の単位を取得
+      unit = Task.find(id).unit
+
       # 期間内の実績の合計値を変数に代入
       total_actions = ActionRecord.where(task_id: id)
         .where(action_day: from...to).select(:action)
@@ -96,6 +99,7 @@ class Api::ActionRecordsController < ApplicationController
 
       task_data.store(:task, task_name)
       task_data.store(:total_goal, total_goal)
+      task_data.store(:unit, unit)
       task_data.store(:total_action, total_actions)
       task_data.store(:achievement_rate, achievement_rate)
 

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -45,6 +45,6 @@ class Api::TasksController < ApplicationController
   private
 
   def task_params
-    params.fetch(:task, {}).permit(:task, :goal, :user_id)
+    params.fetch(:task, {}).permit(:task, :goal, :unit, :user_id)
   end
 end

--- a/app/javascript/packs/components/action_records_index.vue
+++ b/app/javascript/packs/components/action_records_index.vue
@@ -27,7 +27,7 @@
                 </div>
                 <div class="form-group row">
                   <label for="goal" class="col-md-4 col-form-label text-md-right">1週間の目標</label>
-                  <output id="goal" class="form-control col-md-6">{{ goal }}</output>
+                  <output id="goal" class="form-control col-md-6">{{ goal }} {{ unit }}</output>
                 </div>
                 <div class="form-group row">
                   <label for="action" class="col-md-4 col-form-label text-md-right">実績</label>
@@ -70,6 +70,7 @@
         tasks: [],
         selectTask: '',
         goal: '',
+        unit: '',
         ActionRecords: [],
         ActionDay: '',
         action: '',
@@ -126,6 +127,7 @@
         for (var i = 0; i < this.tasks.length; i++) {
           if (this.tasks[i].id == this.selectTask) {
             this.goal = this.tasks[i].goal
+            this.unit = this.tasks[i].unit
           }
         }
         this.searchAction();

--- a/app/javascript/packs/components/action_records_references.vue
+++ b/app/javascript/packs/components/action_records_references.vue
@@ -32,8 +32,8 @@
                 <tbody>
                   <tr v-for="reference_data in references_data" :key="reference_data.id" scope="row">
                     <td>{{ reference_data.task }}</td>
-                    <td>{{ reference_data.total_goal }}</td>
-                    <td>{{ reference_data.total_action }}</td>
+                    <td>{{ reference_data.total_goal }} {{ reference_data.unit }}</td>
+                    <td>{{ reference_data.total_action }} {{ reference_data.unit }}</td>
                     <td>{{ reference_data.achievement_rate }}</td>
                   </tr>
                 </tbody>

--- a/app/javascript/packs/components/mypage.vue
+++ b/app/javascript/packs/components/mypage.vue
@@ -24,8 +24,8 @@
                 <tbody>
                   <tr v-for="reference_data in references_data" :key="reference_data.id" scope="row">
                     <td>{{ reference_data.task }}</td>
-                    <td>{{ reference_data.total_goal }}</td>
-                    <td>{{ reference_data.total_action }}</td>
+                    <td>{{ reference_data.total_goal }} {{ reference_data.unit }}</td>
+                    <td>{{ reference_data.total_action }} {{reference_data.unit }}</td>
                     <td>{{ reference_data.achievement_rate }}</td>
                   </tr>
                 </tbody>

--- a/app/javascript/packs/components/task_edit.vue
+++ b/app/javascript/packs/components/task_edit.vue
@@ -23,6 +23,10 @@
                 <div v-if="taskValidate">
                   <p class="alert alert-danger">{{ goalValidate }}</p>
                 </div>
+                <div class="form-group row">
+                  <label for="unit" class="col-md-4 col-form-label text-md-right">目標の単位</label>
+                  <input id="unit" class="form-control col-md-6" v-model="unit" placeholder="目標">
+                </div>
                 <div class="row">
                   <div class="col-md-8 offset-md-4 justify-content-center">
                     <button class="btn btn-primary mt-1" v-on:click="updateTask">目標修正</button>
@@ -57,6 +61,7 @@ export default {
                 },
       task: '',
       goal: '',
+      unit: '',
       user_id: '',
       taskEditFlg: '',
       taskValidate: '',
@@ -74,7 +79,8 @@ export default {
       ).then((response) => {
         this.task = (response.data.task['task']);
         this.goal = (response.data.task['goal']);
-        this.user_id = (response.data.task['user_id'])
+        this.unit = (response.data.task['unit']);
+        this.user_id = (response.data.task['user_id']);
       }, (error) => {
         console.log(error);
       });
@@ -100,9 +106,8 @@ export default {
       }
 
       if (this.taskEditFlg) {
-        alert('axios')
         axios.put('/api/tasks/' + this.id, 
-                  { task: { task: this.task, goal: this.goal, user_id: this.user_id } }, 
+                  { task: { task: this.task, goal: this.goal, unit: this.unit, user_id: this.user_id } }, 
                   { headers: this.headers }
         ).then((response) => {
           alert('修正しました。')

--- a/app/javascript/packs/components/task_index.vue
+++ b/app/javascript/packs/components/task_index.vue
@@ -19,7 +19,7 @@
                 <tbody>
                   <tr v-for="task in tasks" v-bind:key="task.id" scope="row">
                     <td>{{ task.task }}</td>
-                    <td>{{ task.goal }}</td>
+                    <td>{{ task.goal }} {{ task.unit }}</td>
                     <td>
                       <button class="btn btn-primary" @click="editLink(task.id)">修正</button>
                       <button class="btn btn-primary" @click="deleteTask(task.id)">削除</button>
@@ -46,6 +46,11 @@
     data: function () {
       return {
         tasks: [],
+        headers: {
+                  'access-token': localStorage.getItem('access-token'),
+                  uid: localStorage.getItem('uid'),
+                  client: localStorage.getItem('client') 
+                }
       }
     },
     mounted: function () {
@@ -54,11 +59,7 @@
     methods: {
       fetchTasks: function () {
         axios.get('/api/tasks', 
-                  { headers: {
-                    'access-token': localStorage.getItem('access-token'),
-                    uid: localStorage.getItem('uid'),
-                    client: localStorage.getItem('client') 
-                  }}
+                  { headers: this.headers }
         ).then((response) => {
           for(var i = 0; i < response.data.tasks.length; i++) {
             this.tasks.push(response.data.tasks[i]);

--- a/app/javascript/packs/components/task_new.vue
+++ b/app/javascript/packs/components/task_new.vue
@@ -24,6 +24,10 @@
                   <div v-if="goalValidate">
                     <p class="alert alert-danger">{{ goalValidate }}</p>
                   </div>
+                  <div class="from-group row">
+                    <label for="unit" class="col-md-4 col-form-label text-md-right">目標の単位</label>
+                    <input id="unit" class="form-control col-md-6" v-model="unit" placeholder="目標">
+                  </div>
                   <div v-if="taskNewValidate">
                     <p class="alert alert-danger">{{ taskNewValidate }}</p>
                   </div>
@@ -59,6 +63,7 @@ export default {
                 },
       task: '',
       goal: '',
+      unit: '',
       taskNewflg: false,
       taskValidate: '',
       goalValidate: '',
@@ -88,7 +93,7 @@ export default {
 
       if (this.taskNewflg) {
         axios.post('/api/tasks', 
-                  { task: { task: this.task, goal: this.goal, user_id: localStorage.getItem('user_id') } }, 
+                  { task: { task: this.task, goal: this.goal, unit: this.unit, user_id: localStorage.getItem('user_id') } }, 
                   { headers: this.headers }
         ).then((response) => {
           alert('新規登録しました。')

--- a/app/views/api/action_records/references.json.jbuilder
+++ b/app/views/api/action_records/references.json.jbuilder
@@ -1,5 +1,5 @@
 json.set! :references_data do
   json.array! @references_data do |reference|
-    json.extract! reference, :task, :total_goal, :total_action, :achievement_rate
+    json.extract! reference, :task, :total_goal, :unit, :total_action, :achievement_rate
   end
 end

--- a/app/views/api/tasks/index.json.jbuilder
+++ b/app/views/api/tasks/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.set! :tasks do
   json.array! @tasks do |task|
-    json.extract! task, :id, :task, :goal, :user_id, :created_at, :updated_at
+    json.extract! task, :id, :task, :goal, :user_id, :created_at, :updated_at, :unit
   end
 end

--- a/app/views/api/tasks/show.json.jbuilder
+++ b/app/views/api/tasks/show.json.jbuilder
@@ -1,3 +1,3 @@
 json.set! :task do
-  json.extract! @task, :id, :task, :goal, :user_id, :created_at, :updated_at
+  json.extract! @task, :id, :task, :goal, :user_id, :created_at, :updated_at, :unit
 end

--- a/db/migrate/20210224071855_add_column_tasks.rb
+++ b/db/migrate/20210224071855_add_column_tasks.rb
@@ -1,0 +1,5 @@
+class AddColumnTasks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tasks, :unit, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_20_101054) do
+ActiveRecord::Schema.define(version: 2021_02_24_071855) do
 
   create_table "action_records", id: :integer, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "action_day", null: false
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2021_02_20_101054) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "unit"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 


### PR DESCRIPTION
Closes #116 

- tasksテーブルに目標の単位を追加
  - string型のunitカラムをtasksテーブルに追加
  

- 各ページで単位を表示するように修正
  - tasks_controllerのストロングパラメータにunitを追加
  - tasks/index.json.jbuilder,tasks/show.json.jbuilder,action_records/references.json.jbuilderにunitを追加
  - mypage.vue,task_index.vue,task_new.vue,task_edit.vue,action_records_index.vue,action_records_references.vueで単位を表示するように修正