### PR TITLE
モデルのバリデーションのエラーメッセージをフロントで表示するように実装 #118

### DIFF
--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -28,13 +28,13 @@ class Api::ActionRecordsController < ApplicationController
       if @action_record.save
         render :show, status: :created
       else
-        render json: @action_record.errors, status: :unprocessable_entity
+        render json: { errors: @action_record.errors.keys.map { |key| [key, @action_record.errors.full_messages_for(key)] }.to_h, render: "show.json.jbuilder" }, status: :unprocessable_entity
       end
     else
       if @action_record.update(action_record_params)
         render :show, status: :ok
       else
-        render json: @action_record.errors, status: :unprocessable_entity
+        render json: { errors: @action_record.errors.keys.map { |key| [key, @action_record.errors.full_messages_for(key)] }.to_h, render: "show.json.jbuilder" }, status: :unprocessable_entity
       end
     end
   end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -15,7 +15,7 @@ class Api::TasksController < ApplicationController
     if @task.save
       render :index, status: :created
     else
-      render json: @task.errors, status: :unprocessable_entity
+      render json: { errors: @task.errors.keys.map { |key| [key, @task.errors.full_messages_for(key)] }.to_h, render: "index.json.jbuilder" }, status: :unprocessable_entity
     end
   end
 
@@ -29,7 +29,7 @@ class Api::TasksController < ApplicationController
     if @task.update(task_params)
       render :show, status: :ok
     else
-      render json: @task.errors, status: :unprocessable_entity
+      render json: { errors: @task.errors.keys.map { |key| [key, @task.errors.full_messages_for(key)] }.to_h, render: "show.json.jbuilder" }, status: :unprocessable_entity
     end
   end
 
@@ -38,7 +38,7 @@ class Api::TasksController < ApplicationController
     if @task.destroy
       render :index, status: :ok
     else
-      render json: @task.errors, status: :unprocessable_entity
+      render json: { errors: @task.errors.keys.map { |key| [key, @task.errors.full_messages_for(key)] }.to_h, render: "index.json.jbuilder" }, status: :unprocessable_entity
     end
   end
 

--- a/app/javascript/packs/components/action_records_index.vue
+++ b/app/javascript/packs/components/action_records_index.vue
@@ -187,7 +187,16 @@
             alert('登録しました。')
           }, (error) => {
             console.log(error)
-            this.actionRecordValidate = '登録に失敗しました。'
+            if (error.response.data && error.response.data.errors) {
+              var errors = error.response.data.errors
+              if (!!errors['action_day']) {
+                this.actionDayValidate = this.errors = errors['action_day'][0]
+              } else if (!!errors['action']) {
+                this.actionValidate = errors['action'][0]
+              }
+            } else {
+              this.actionRecordValidate = '登録に失敗しました。'
+            }
           })
         }
         alert('check')

--- a/app/javascript/packs/components/task_edit.vue
+++ b/app/javascript/packs/components/task_edit.vue
@@ -113,7 +113,16 @@ export default {
           alert('修正しました。')
         }, (error) => {
           console.log(error);
-          this.taskEditValidate = 'タスクの修正に失敗しました。'
+          if (error.response.data && error.response.data.errors) {
+            var errors = error.response.data.errors
+            if (!!errors['task']) {
+              this.taskValidate = this.errors = errors['task'][0]
+            } else if (!!errors['goal']) {
+              this.goalValidate = errors['goal'][0]
+            }
+          } else {
+            this.taskEditValidate = 'タスクの修正に失敗しました。'
+          }
         });
       }
     }

--- a/app/javascript/packs/components/task_new.vue
+++ b/app/javascript/packs/components/task_new.vue
@@ -99,7 +99,16 @@ export default {
           alert('新規登録しました。')
         }, (error) => {
           console.log(error);
-          this.taskNewValidate = 'タスクの登録に失敗しました。'
+          if (error.response.data && error.response.data.errors) {
+            var errors = error.response.data.errors
+            if (!!errors['task']) {
+              this.taskValidate = this.errors = errors['task'][0]
+            } else if (!!errors['goal']) {
+              this.goalValidate = errors['goal'][0]
+            }
+          } else {
+            this.taskNewValidate = 'タスクの登録に失敗しました。'
+          }
         });
       }
     }


### PR DESCRIPTION
Closes #118 

- モデルのバリデーションのエラーメッセージをフロントで表示するように実装
  - task_controller,action_records_controllerのcreate,updateでエラー時にモデルのバリデーションエラーを取得するように実装
  - task_new.vue,task_edit.vue,action_records_index.vueで非同期通信のエラー時にエラーメッセージがある場合に取得するように実装