### PR TITLE
ナビバーの表示非表示のユーザ認証を修正 #120

### DIFF
--- a/app/javascript/packs/components/header.vue
+++ b/app/javascript/packs/components/header.vue
@@ -43,14 +43,16 @@
         if (!localStorage.getItem('access-token')) {
           this.user_login_flg = false
         } else {
-          axios.get('api/auth/validate_token',
+          this.user_login_flg = true
+          /* axios.get('api/auth/validate_token',
                     { headers: this.headers}
           ).then((response) => {
             this.user_login_flg = true
           }, (error) => {
+            console.log('認証失敗')
             this.user_login_flg = false
             console.log(error)
-          })
+          }) */
         }
       },
       logoutUser: function () {


### PR DESCRIPTION
Closes #120 

- ナビバーの表示非表示のユーザ認証を修正
  - タスク新規作成、修正画面、行動記録画面でナビバーのログイン未ログインを判定するユーザ認証が失敗する。
  - 原因を調べても分からなかったため、ローカルストレージにアクセストークンがあるかないかで判別する処理に修正。