### PR TITLE
未ログイン時にログイン画面に遷移するように実装 #124

### DIFF
--- a/app/javascript/packs/router/router.js
+++ b/app/javascript/packs/router/router.js
@@ -18,15 +18,18 @@ export default new VueRouter ({
   routes: [
     {
       path: '/',
-      component: Top
+      component: Top,
+      meta: { isPublic: true }
     },
     {
       path: '/signup',
-      component: SignUp
+      component: SignUp,
+      meta: { isPublic: true }
     },
     {
       path: '/login',
-      component: Login
+      component: Login,
+      meta: { isPublic: true }
     },
     {
       path: '/account',

--- a/app/javascript/packs/todo.js
+++ b/app/javascript/packs/todo.js
@@ -2,6 +2,15 @@ import Vue from 'vue/dist/vue.esm.js'
 import router from './router/router'
 import Header from './components/header.vue'
 
+router.beforeEach((to, from, next) => {
+    // isPublicでない場合(=認証が必要な場合)、かつ、ローカルストレージにアクセストークンを保持していない場合
+    if (to.matched.some(record => !record.meta.isPublic) && !localStorage.getItem('access-token')) {
+      next({ path: '/login', query: { redirect: to.fullPath }});
+    } else {
+      next();
+    }
+});
+
 var app = new Vue ({
   router,
   el: '#app',


### PR DESCRIPTION
Closes #124 

- 未ログイン時にログイン画面に遷移するように実装
  - router.jsでユーザ認証が必要ないパスに`meta: { isPublic: true }`を追加
  - todo.jsで`beforeEach`を使用し、ルートに`meta: { isPublic: true }`が設定されておらず、ローカルストレージにアクセストークンが保持されていない場合にログイン画面に遷移するように実装