### PR TITLE
レベル表示の追加とリファクタリング# 147

### DIFF
--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -16,19 +16,19 @@ class Api::ActionRecordsController < ApplicationController
                                           user_id: action_record_params[:user_id])
 
     # レベル処理を行う
-    levelup_data = levelUpAndDown(action_record_params[:task_id], action_record_params[:action_day], action_record_params[:action])
+    @levelup_data = levelUpAndDown(action_record_params[:task_id], action_record_params[:action_day], action_record_params[:action])
 
     if (@action_record.nil?)
       @action_record = ActionRecord.new(action_record_params)
 
       if @action_record.save
-        render :show, status: :created
+        render :registration, status: :created
       else
         render json: { errors: @action_record.errors.keys.map { |key| [key, @action_record.errors.full_messages_for(key)] }.to_h, render: "show.json.jbuilder" }, status: :unprocessable_entity
       end
     else
       if @action_record.update(action_record_params)
-        render :show, status: :ok
+        render :registration, status: :ok
       else
         render json: { errors: @action_record.errors.keys.map { |key| [key, @action_record.errors.full_messages_for(key)] }.to_h, render: "show.json.jbuilder" }, status: :unprocessable_entity
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,9 +39,23 @@ class ApplicationController < ActionController::Base
 
     # レベルを取得
     level = user_level.getUserLevel(current_user.id)
+    before_level = level
 
-    # 次レベルの経験値を取得
+    # 現在のレベルの必要経験値を取得
+    current_level_required_experience_point = level_info.getRequreidExperiecePoint(level)
+
+    # 次レベルの必要経験値を取得
     next_level_required_experience_point = level_info.getRequreidExperiecePoint(level + 1)
+
+    puts "total"
+    puts total_experience_point
+    puts "current"
+    puts current_level_required_experience_point
+    puts "next"
+    puts next_level_required_experience_point
+
+    # 変更前のレベルの経験値テーブルにおける%を計算する
+    before_experience_point_percent = ((total_experience_point - current_level_required_experience_point).to_f / (next_level_required_experience_point - current_level_required_experience_point).to_f * 100).floor
 
     # 既にデータが存在しているかチェック
     if (action_record.checkActionRecord?(action_day, task_id, current_user.id).nil?)
@@ -149,13 +163,28 @@ class ApplicationController < ActionController::Base
     # 次のレベルアップに必要な経験値を計算する
     until_levelup = level_info.getNextLevelRequreidExperiencePoint(level, total_experience_point)
 
+    # レベル処理後のレベル
+    after_level = UserLevel.find_by(user_id: current_user.id).level
+
+    # レベル処理後のレベルの必要経験値
+    current_level_required_experience_point = level_info.getRequreidExperiecePoint(after_level)
+
+    # 変更後のレベルの経験値テーブルにおけるを計算する
+    after_experience_point_percent = ((total_experience_point - current_level_required_experience_point).to_f / (next_level_required_experience_point - current_level_required_experience_point).to_f * 100).floor
+
+    puts "--------------------------"
+    puts before_level
+    puts after_level
+    puts before_experience_point_percent
+    puts after_experience_point_percent
+    puts "---------------------------"
+
     # 配列を作って情報を返す
     levelup_data = {}
-    levelup_data.store(:level, level)
-    levelup_data.store(:total_experience_point, total_experience_point)
-    levelup_data.store(:next_level_required_experience_point, next_level_required_experience_point)
-    levelup_data.store(:until_levelup, until_levelup)
-    levelup_data.store(:user_id, current_user.id)
+    levelup_data.store(:before_level, before_level)
+    levelup_data.store(:after_level, after_level)
+    levelup_data.store(:before_experience_point_percent, before_experience_point_percent)
+    levelup_data.store(:after_experience_point_percent, after_experience_point_percent)
 
     levelup_data
   end

--- a/app/views/api/action_records/registration.json.jbuilder
+++ b/app/views/api/action_records/registration.json.jbuilder
@@ -1,0 +1,5 @@
+json.set! :level_up_data do
+  json.extract! @levelup_data, :before_level, :after_level,
+                :before_experience_point_percent,
+                :after_experience_point_percent
+end


### PR DESCRIPTION
Closes #147  

- フロント側でレベル処理を実装
  - application.controllerのメソッドで返すハッシュのデータを修正
  - action_records/registration.json.jbuilderを作成
  - action_records.controllerのcreateOrUpdateメソッドの返すjbuilderファイルをregistration.json.jbuilderに修正
  - actionRecordsRegistraion.vueで登録成功時にレベル処理を行うように修正
  - actionRecordsRegistraion.vueにupdateProgress,updateProgressLevelUp, updateProgressLevelDownメソッドを追加
  - 画面にレベルと経験値バーと表示