### PR TITLE
モデルのバリデーションを修正し、それに伴いフロントのバリデーションを修正 #165

### DIFF
--- a/app/javascript/packs/components/ActionRecordsRegistration.vue
+++ b/app/javascript/packs/components/ActionRecordsRegistration.vue
@@ -26,7 +26,7 @@
               </div>
               <div class="form-group row">
                 <label for="action" class="col-md-4 col-form-label text-md-right">実績</label>
-                <input type="text" id="action" class="form-control col-md-6" v-model.trim="action">
+                <input type="text" id="action" class="form-control col-md-6" v-model.trim.number="action">
                 <span v-if="!validationAction" class="col-md-6 offset-md-4 text-warning">{{ actionValidateMessage }}</span>
                 <span v-if="!!actionRecordValidateMessage" class="col-md-6 offset-md-4 text-warning">{{ actionRecordValidateMessage }}</span>
                 <span v-if="!!actionRecordSuccessMessage" class="mt-3 mb-0 mx-auto alert alert-primary">{{ actionRecordSuccessMessage }}</span>
@@ -199,6 +199,7 @@
                   { headers: this.headers }
         ).then((response) => {
           this.actionRecordSuccessMessage = '行動を記録しました'
+          this.actionRecordValidateMessage = ''
 
           this.before_level = response.data.level_up_data['before_level']
           this.after_level = response.data.level_up_data['after_level']
@@ -224,15 +225,15 @@
           }
         }, (error) => {
           console.log(error)
+          this.actionRecordSuccessMessage = ''
+          this.actionRecordValidateMessage = '登録に失敗しました'
           if (error.response.data && error.response.data.errors) {
             var errors = error.response.data.errors
             if (!!errors['action_day']) {
-              this.actionDayValidateMessage = this.errors = errors['action_day'][0]
+              this.actionRecordValidateMessage = errors['action_day'][0].replace('Action_day', '日付')
             } else if (!!errors['action']) {
-              this.actionValidateMessage = errors['action'][0]
+              this.actionRecordValidateMessage = errors['action'][0].replace('Action', '実績')
             }
-          } else {
-            this.actionRecordValidateMessage = '登録に失敗しました。'
           }
         })
       },

--- a/app/javascript/packs/components/TaskEdit.vue
+++ b/app/javascript/packs/components/TaskEdit.vue
@@ -21,7 +21,7 @@
               <div class="form-group row">
                 <label for="unit" class="col-md-4 col-form-label text-md-right">目標の単位</label>
                 <input type="text" id="unit" class="form-control col-md-6" v-model.trim="unit" placeholder="例)km、分">
-                <span v-if="!!taskEditValidateMessage" class="col-md-6 offset-md-4 text-warning">{{ taskEditValidateMessage }}</span>
+                <span v-if="!!taskEditValidateMessage" class="mt-3 mb-0 mx-auto alert alert-danger">{{ taskEditValidateMessage }}</span>
                 <span v-if="!!taskEditSuccessMessage" class="mt-3 mb-0 mx-auto alert alert-primary">{{ taskEditSuccessMessage }}</span>
               </div>
               <div class="row">
@@ -74,6 +74,9 @@ export default {
       if (!this.task) {
         this.taskValidateMessage = '習慣が空です。'
         return false
+      } else if (this.task.length > 30) {
+        this.taskValidateMessage = '習慣は30文字以内で入力してください'
+        return false
       }
       return true
     },
@@ -110,15 +113,15 @@ export default {
         this.taskEditValidateMessage = ''
       }, (error) => {
         console.log(error);
+        this.taskEditSuccessMessage = ''
+        this.taskEditValidateMessage = '習慣の修正に失敗しました'
         if (error.response.data && error.response.data.errors) {
           var errors = error.response.data.errors
           if (!!errors['task']) {
-            this.taskValidateMessage = errors['task'][0]
+            this.taskEditValidateMessage = errors['task'][0].replace('Task', '習慣')
           } else if (!!errors['goal']) {
-            this.goalValidateMessage = errors['goal'][0]
+            this.taskEditValidateMessage = errors['goal'][0].replace('Goal', '目標')
           }
-        } else {
-          this.taskEditValidateMessage = '習慣の修正に失敗しました。'
         }
       });
     }

--- a/app/javascript/packs/components/TaskNew.vue
+++ b/app/javascript/packs/components/TaskNew.vue
@@ -21,7 +21,7 @@
               <div class="from-group row">
                 <label for="unit" class="col-md-4 col-form-label text-md-right">目標の単位</label>
                 <input type="text" id="unit" class="form-control col-md-6" v-model.trim="unit" placeholder="例)km、分">
-                <span v-if="!!taskNewValidateMessage" class="col-md-6 offset-md-4 text-warning">{{ taskNewValidateMessage }}</span>
+                <span v-if="!!taskNewValidateMessage" class="mt-3 mb-0 mx-auto alert alert-danger">{{ taskNewValidateMessage }}</span>
                 <span v-if="!!taskNewSuccessMessage" class="mt-3 mb-0 mx-auto alert alert-primary">{{ taskNewSuccessMessage }}</span>
               </div>
               <div class="row">
@@ -67,6 +67,9 @@ export default {
       if (!this.task) {
         this.taskValidateMessage = '習慣が空です。'
         return false
+      } else if (this.task.length > 30) {
+        this.taskValidateMessage = '習慣は30文字以内で入力してください'
+        return false
       }
       return true
     },
@@ -88,18 +91,19 @@ export default {
                 { headers: this.headers }
       ).then((response) => {
         alert('新規登録しました。')
+        this.taskValidateMessage = ''
         this.taskNewSuccessMessage = '習慣を新規登録しました'
       }, (error) => {
         console.log(error);
+        this.taskNewSuccessMessage = ''
+        this.taskNewValidateMessage = '習慣の登録に失敗しました'
         if (error.response.data && error.response.data.errors) {
           var errors = error.response.data.errors
           if (!!errors['task']) {
-            this.taskValidate = this.errors = errors['task'][0]
+            this.taskNewValidateMessage = errors['task'][0].replace('Task', '習慣')
           } else if (!!errors['goal']) {
-            this.goalValidate = errors['goal'][0]
+            this.taskNewValidateMessage = errors['goal'][0].replace('Goal', '目標')
           }
-        } else {
-          this.taskNewValidateMessage = '習慣の登録に失敗しました。'
         }
       });
     }

--- a/app/javascript/packs/components/UserLogin.vue
+++ b/app/javascript/packs/components/UserLogin.vue
@@ -16,7 +16,7 @@
               <label for="password" class="col-md-4 col-form-label text-md-right">パスワード</label>
               <input v-model.trim="user.password" id="password" class="form-control col-md-6" type="password" placeholder="password">
               <span v-if="!validationPassword" class="col-md-6 offset-md-4 text-warning">{{ passwordValidateMessage }}</span>
-              <span v-if="!!loginValidateMessage" class="mt-3 mb-0 mx-auto alert alert-warning">{{ loginValidateMessage }}</span>
+              <span v-if="!!loginValidateMessage" class="mt-3 mb-0 mx-auto alert alert-danger">{{ loginValidateMessage }}</span>
             </div>
             <div class="row">
               <button @click="loginUser" :disabled="!validation" class="btn btn-primary mt-1 mx-auto d-block">ログイン</button>
@@ -49,12 +49,14 @@
       },
       validationEmail: function () {
         const emailRegExp = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/
-        
         if (!this.user.email) {
-          this.emailValidateMessage = 'メールアドレスが空です。'
+          this.emailValidateMessage = 'メールアドレスが空です'
           return false
         } else if (!emailRegExp.test(this.user.email)) {
-          this.emailValidateMessage = 'メールアドレスの形式が間違っています。'
+          this.emailValidateMessage = 'メールアドレスの形式が間違っています'
+          return false
+        } else if (this.user.email.length > 255) {
+          this.emailValidateMessage = 'メールアドレスは255文字以内で入力してください'
           return false
         }
         return true
@@ -63,13 +65,13 @@
         const passwordRegExp = /^[0-9a-zA-Z]*$/
 
         if (!this.user.password) {
-          this.passwordValidateMessage = 'パスワードが空です。'
+          this.passwordValidateMessage = 'パスワードが空です'
           return false
         } else if (!passwordRegExp.test(this.user.password)) {
-          this.passwordValidateMessage = 'パスワードは半角英数字で入力してください。'
+          this.passwordValidateMessage = 'パスワードは半角英数字で入力してください'
           return false
         } else if (this.user.password.length < 6) {
-          this.passwordValidateMessage = 'パスワードは6文字以上です。'
+          this.passwordValidateMessage = 'パスワードは6文字以上です'
           return false
         }
         return true
@@ -89,8 +91,9 @@
           return response
         }, (error) => {
           console.log(error)
+          error.response.data.errors
           if (error.response.status == 401) {
-            this.loginValidateMessage = "メールアドレスかパスワードが間違っています。"
+            this.loginValidateMessage = "メールアドレスかパスワードが間違っています"
           }
         })
       }

--- a/app/javascript/packs/components/UserSignUp.vue
+++ b/app/javascript/packs/components/UserSignUp.vue
@@ -26,7 +26,7 @@
               <label for="passwordConfirmation" class="col-md-4 col-form-label text-md-right">パスワード(確認)</label>
               <input v-model.trim="user.passwordConfirmation" id="passwordConfirmation" class="form-control col-md-6" type="password" placeholder="passwordConfirmation">
               <span v-if="!validationPasswordConfirm" class="col-md-6 offset-md-4 text-warning">{{ passwordConfirmValidateMessage }}</span>
-              <span v-if="!!signUpValidateMessage" class="mt-3 mb-0 mx-auto alert alert-warning">{{ signUpValidateMessage }}</span>
+              <span v-if="!!signUpValidateMessage" class="mt-3 mb-0 mx-auto alert alert-danger">{{ signUpValidateMessage }}</span>
             </div>
             <div class="row">
               <button @click="registerUser" :disabled="!validation" class="btn btn-primary mt-1 mx-auto d-block">登録</button>
@@ -64,8 +64,10 @@
       },
       validationName: function () {
         if (!this.user.name) {
-          this.nameValidateMessage = 'ユーザ名が空です。'
+          this.nameValidateMessage = 'ユーザ名が空です'
           return false
+        } else if (this.user.name.length > 25) {
+          this.nameValidateMessage = 'ユーザ名は25文字以内で入力してください'
         }
         return true
       },
@@ -73,10 +75,13 @@
         const emailRegExp = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/
 
         if (!this.user.email) {
-          this.emailValidateMessage = 'メールアドレスが空です。'
+          this.emailValidateMessage = 'メールアドレスが空です'
           return false
         } else if (!emailRegExp.test(this.user.email)) {
-          this.emailValidateMessage = 'メールアドレスの形式が間違っています。'
+          this.emailValidateMessage = 'メールアドレスの形式が間違っています'
+          return false
+        } else if (this.user.email.length > 255) {
+          this.emailValidateMessage = 'メールアドレスは255文字以内で入力してください'
           return false
         }
         return true
@@ -88,20 +93,20 @@
           this.passwordValidateMessage = 'パスワードが空です'
           return false
         } else if (!passwordRegExp.test(this.user.password)) {
-          this.passwordValidateMessage = 'パスワードは半角英数字で入力してください。'
+          this.passwordValidateMessage = 'パスワードは半角英数字で入力してください'
           return false
         } else if (this.user.password.length < 6) {
-          this.passwordValidateMessage = 'パスワードは6文字以上です。'
+          this.passwordValidateMessage = 'パスワードは6文字以上です'
           return false
         }
         return true
       },
       validationPasswordConfirm: function () {
         if (!this.user.passwordConfirmation) {
-          this.passwordConfirmValidateMessage = 'パスワード(確認)が空です。'
+          this.passwordConfirmValidateMessage = 'パスワード(確認)が空です'
           return false
         } else if (this.user.password !== this.user.passwordConfirmation) {
-          this.passwordConfirmValidateMessage = 'パスワードと一致しません。'
+          this.passwordConfirmValidateMessage = 'パスワードと一致しません'
           return false
         }
         return true
@@ -128,7 +133,7 @@
         }, (error) => {
           console.log(error)
           if (error.response.status == 422) {
-            this.signUpValidateMessage = "登録に失敗しました。もう一度試してください。"
+            this.signUpValidateMessage = "登録に失敗しました。もう一度試してください"
           }
         })
       }

--- a/app/models/action_record.rb
+++ b/app/models/action_record.rb
@@ -3,8 +3,8 @@ class ActionRecord < ApplicationRecord
   belongs_to :task
 
   validates :action_day, presence: true
-  validates :action, presence: true
-  validates :action_experience_point, presence: true
+  validates :action, presence: true, numericality: true
+  validates :action_experience_point, presence: true, numericality: true
   validates :action_day, uniqueness: { scope: [:task_id, :user_id] }
 
   PERCENT = 100

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,6 +2,6 @@ class Task < ApplicationRecord
   belongs_to :user
   has_many :action_records, dependent: :destroy
 
-  validates :task, presence: true
-  validates :goal, presence: true
+  validates :task, presence: true, length: { maximum: 30 }
+  validates :goal, presence: true, numericality: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,9 @@ class User < ApplicationRecord
   has_many :action_records, dependent: :destroy
   has_many :user_levels, dependent: :destroy
 
-  validates :name, presence: true
-  validates :email, presence: true, uniqueness: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+  validates :name, presence: true, length: { maximum: 25 }
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  validates :email, presence: true, uniqueness: true, length: { maximum: 255 }, format: { with: VALID_EMAIL_REGEX }
+  validates :password, presence: true, length: { minimum: 6 }
+  validates :password_confirmation, presence: true, length: { minimum: 6 }
 end


### PR DESCRIPTION
Closes #165 

- モデルのバリデーションを修正
  - action_recordモデル
    - actionカラムで受け付ける値を数字に修正
    - experience_pointカラムで受け付ける値を数字に修正
  - taskモデル
    - taskカラムを25文字以内に修正
    - goalカラムで受け付ける値を数字に修正 
  - userモデル
    - nameカラムを25文字以内に修正
    - emailカラムを255文字以内に修正
    - passwaordカラムを追加し、6文字以上に修正
    - password_confirmationカラムを追加し、6文字以上に修正

- フロントのバリデーションを修正
  - TaskNew.vue、TaskEdit.vue
    - taskが30文字を超える場合のバリデーションを追加
  - ActionRecordsRegistration.vue
    - 実績の入力欄のv-modelにnumber修飾子を追加
  - UserLogin.vue、UserSignUp.vue
    - ユーザ名が25文字を超える場合のバリデーションを追加
    - メールアドレスが255文字を超える場合のバリデーションを追加