### PR TITLE
リクエストヘッダーにcsrf-tokenを自動で追加するプラグインを実装 #177

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
   skip_before_action :verify_authenticity_token, if: :devise_controller?
-  protect_from_forgery with: :null_session
 
   # 目標達成時の経験値
   ACHIEVEMENTEXPERIENCEPOINT = 100

--- a/app/javascript/packs/plugins/vue-axios.js
+++ b/app/javascript/packs/plugins/vue-axios.js
@@ -1,0 +1,17 @@
+const VueAxiosPlugin = {}
+export default VueAxiosPlugin.install = function(Vue, { axios }) {
+  const csrf_token = document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+  axios.defaults.headers.common = {
+    "X-Requested-With": "XMLHttpRequest",
+    "X-CSRF-Token": csrf_token
+  }
+
+  Vue.axios = axios
+  Object.defineProperties(Vue.prototype, {
+    axios: {
+      get () {
+        return axios
+      }
+    }
+  })
+}

--- a/app/javascript/packs/todo.js
+++ b/app/javascript/packs/todo.js
@@ -1,6 +1,10 @@
 import Vue from 'vue/dist/vue.esm.js'
 import router from './router/router'
 import Header from './components/NaviBar.vue'
+import VueAxiosPlugin from "./plugins/vue-axios"
+import axios from 'axios'
+
+Vue.use(VueAxiosPlugin, { axios: axios })
 
 router.beforeEach((to, from, next) => {
     // isPublicでない場合(=認証が必要な場合)、かつ、ローカルストレージにアクセストークンを保持していない場合


### PR DESCRIPTION
Closes #177 

- リクエストヘッダーにcsrf-tokenを自動で追加するプラグインを実装
  - app/javascript/packs配下にpluginフォルダを作成
  - vue-axios.jsを作成しrequest headerに `csrf-token` を自動で追加するファイルを追加
  - application_controller.rbから `protect_from_forgery with: :null_session` を削除