### PR TITLE
リクエスト時に自動でaccess-tokne,uid,clientを乗せるように実装 #183

### DIFF
--- a/app/javascript/packs/components/ActionRecordsReferences.vue
+++ b/app/javascript/packs/components/ActionRecordsReferences.vue
@@ -55,11 +55,6 @@ export default {
   data: function () {
     return {
       interval: 'thisMonth',
-      headers: {
-                  'access-token': localStorage.getItem('access-token'),
-                  uid: localStorage.getItem('uid'),
-                  client: localStorage.getItem('client') 
-                },
       referencesData: []
     }
   },
@@ -69,9 +64,7 @@ export default {
   methods: {
     getReferencesData: function () {
       axios.get('/api/action_records/actionRecordReferences', 
-                { params: { interval: this.interval },
-                  headers: this.headers
-                }
+                { params: { interval: this.interval } }        
       ).then((response) => {
         this.referencesData.splice(0)
         for(var i = 0; i <response.data.references_data.length; i++) {

--- a/app/javascript/packs/components/ActionRecordsRegistration.vue
+++ b/app/javascript/packs/components/ActionRecordsRegistration.vue
@@ -71,11 +71,6 @@
   export default {
     data: function () {
       return {
-        headers: {
-                  'access-token': localStorage.getItem('access-token'),
-                  uid: localStorage.getItem('uid'),
-                  client: localStorage.getItem('client') 
-                },
         tasks: [],
         selectTask: '',
         goal: '',
@@ -142,9 +137,7 @@
         this.ActionDay = yyyy + '-' + mm+'-' + dd;
       },
       fetchTasks: function () {
-        axios.get('/api/tasks', 
-                  { headers: this.headers }
-        ).then((response) => {
+        axios.get('/api/tasks').then((response) => {
           for(var i = 0; i < response.data.tasks.length; i++) {
             this.tasks.push(response.data.tasks[i]);
           }
@@ -153,9 +146,7 @@
         });
       },
       fetchActionRecord: function () {
-        axios.get('/api/action_records', 
-                  { headers: this.headers }
-        ).then((response) => {
+        axios.get('/api/action_records').then((response) => {
           for(var i = 0; i < response.data.action_records.length; i++) {
             this.ActionRecords.push(response.data.action_records[i]);
           }
@@ -195,8 +186,7 @@
         this.culculateActionExperiencePoint();
         axios.post('/api/action_records/createOrUpdate', 
                   { action_record: { action_day: this.ActionDay, action: Number(this.action), 
-                    action_experience_point: this.action_experience_point, user_id: localStorage.getItem('user_id'), task_id: this.selectTask }},
-                  { headers: this.headers }
+                    action_experience_point: this.action_experience_point, user_id: localStorage.getItem('user_id'), task_id: this.selectTask }}
         ).then((response) => {
           this.actionRecordSuccessMessage = '行動を記録しました'
           this.actionRecordValidateMessage = ''
@@ -238,22 +228,18 @@
         })
       },
       updateProgress: function () {
-        console.log('updateProgress')
         if (this.stateFlg) {
           this.state += 1
         } else {
           this.state -= 1
         }
-        console.log("progress:", this.state, "%");
 
         if (this.state == this.endState) {
           clearInterval(this.intervalId);
-          console.log('経験値処理終了')
         }
       },
       updateProgressLevelUp: function () {
         this.state += 1
-        console.log("progress:", this.state, "%");
         
         if (this.state == 100) {
           this.state = 0
@@ -268,7 +254,6 @@
       },
       updateProgressLevelDown: function () {
         this.state -= 1
-        console.log("progress:", this.state, "%");
 
         if (this.state == 0) {
           this.state = 100

--- a/app/javascript/packs/components/NaviBar.vue
+++ b/app/javascript/packs/components/NaviBar.vue
@@ -29,11 +29,6 @@
     data: function () {
       return {
         userLoginFlg: false,
-        headers: {
-                  'access-token': localStorage.getItem('access-token'),
-                  uid: localStorage.getItem('uid'),
-                  client: localStorage.getItem('client') 
-                },
       }
     },
     mounted: function () {
@@ -70,11 +65,9 @@
         }
       },
       logoutUser: function () {
-        axios.delete('/api/auth/sign_out', 
-                    { headers: this.headers } 
-        ).then((response) => {
-            localStorage.clear()
-            location.href = "http://localhost:3000/"
+        axios.delete('/api/auth/sign_out').then((response) => {
+          localStorage.clear()
+          location.href = "http://localhost:3000/"
         }, (error) => {
           console.log(error)
         })

--- a/app/javascript/packs/components/TaskEdit.vue
+++ b/app/javascript/packs/components/TaskEdit.vue
@@ -48,11 +48,6 @@ export default {
   },
   data: function () {
     return {
-      headers: {
-                  'access-token': localStorage.getItem('access-token'),
-                  uid: localStorage.getItem('uid'),
-                  client: localStorage.getItem('client') 
-                },
       task: '',
       goal: '',
       unit: '',
@@ -93,9 +88,7 @@ export default {
   },
   methods: {
     fetchTasks: function () {
-      axios.get('/api/tasks/' + this.id, 
-                { headers: this.headers }
-      ).then((response) => {
+      axios.get('/api/tasks/' + this.id).then((response) => {
         this.task = (response.data.task['task']);
         this.goal = (response.data.task['goal']);
         this.unit = (response.data.task['unit']);
@@ -106,8 +99,7 @@ export default {
     },
     updateTask: function () {
       axios.put('/api/tasks/' + this.id, 
-                { task: { task: this.task, goal: this.goal, unit: this.unit, user_id: this.userId } }, 
-                { headers: this.headers }
+                { task: { task: this.task, goal: this.goal, unit: this.unit, user_id: this.userId } }
       ).then((response) => {
         this.taskEditSuccessMessage = '習慣を編集しました'
         this.taskEditValidateMessage = ''

--- a/app/javascript/packs/components/TaskIndex.vue
+++ b/app/javascript/packs/components/TaskIndex.vue
@@ -49,11 +49,6 @@
     data: function () {
       return {
         tasks: [],
-        headers: {
-                  'access-token': localStorage.getItem('access-token'),
-                  uid: localStorage.getItem('uid'),
-                  client: localStorage.getItem('client') 
-                },
         taskErrorMessage: ''
       }
     },
@@ -62,9 +57,7 @@
     },
     methods: {
       fetchTasks: function () {
-        axios.get('/api/tasks', 
-                  { headers: this.headers }
-        ).then((response) => {
+        axios.get('/api/tasks').then((response) => {
           for(var i = 0; i < response.data.tasks.length; i++) {
             this.tasks.push(response.data.tasks[i]);
           }
@@ -74,9 +67,7 @@
       },
       deleteTask: function (task_id) {
         axios.delete('/api/tasks/' + task_id, 
-                    { data: {id: task_id}, 
-                      headers: this.headers 
-                    }
+                    { data: {id: task_id}}
         ).then((response) => {
           location.reload();
         }, (error) => {

--- a/app/javascript/packs/components/TaskNew.vue
+++ b/app/javascript/packs/components/TaskNew.vue
@@ -45,11 +45,6 @@ import axios from 'axios'
 export default {
   data: function () {
     return {
-      headers: {
-                  'access-token': localStorage.getItem('access-token'),
-                  uid: localStorage.getItem('uid'),
-                  client: localStorage.getItem('client') 
-                },
       task: '',
       goal: '',
       unit: '',
@@ -87,8 +82,7 @@ export default {
   methods: {
     createTask: function () {
       axios.post('/api/tasks', 
-                { task: { task: this.task, goal: this.goal, unit: this.unit, user_id: localStorage.getItem('user_id') } }, 
-                { headers: this.headers }
+                { task: { task: this.task, goal: this.goal, unit: this.unit, user_id: localStorage.getItem('user_id') } }
       ).then((response) => {
         alert('新規登録しました。')
         this.taskValidateMessage = ''

--- a/app/javascript/packs/components/UserMyPage.vue
+++ b/app/javascript/packs/components/UserMyPage.vue
@@ -51,12 +51,7 @@
       return {
         name: localStorage.getItem('name'),
         level: '',
-        referencesData: [],
-        headers: {
-                  'access-token': localStorage.getItem('access-token'),
-                  uid: localStorage.getItem('uid'),
-                  client: localStorage.getItem('client') 
-                },
+        referencesData: []
       }
     },
     mounted: function () {
@@ -66,9 +61,7 @@
     methods: {
       fetchReferencesData: function () {
         axios.get('/api/action_records/actionRecordReferences', 
-                  { params: { interval: "thisWeek" },
-                    headers: this.headers
-                  }
+                  { params: { interval: "thisWeek" } }
       ).then((response) => {
         this.referencesData.splice(0)
         for(var i = 0; i <response.data.references_data.length; i++) {
@@ -80,9 +73,7 @@
       },
       fetchUserLevel: function () {
         axios.get('/api/user_levels',
-                  { params: { user_id: localStorage.getItem('user_id') },
-                    headers: this.headers
-                  }
+                  { params: { user_id: localStorage.getItem('user_id') } }
         ).then((response) => {
           this.level = response.data.user_level.level
         }, (error) => {

--- a/app/javascript/packs/components/UserSignUp.vue
+++ b/app/javascript/packs/components/UserSignUp.vue
@@ -124,7 +124,7 @@
           localStorage.setItem('name', response.data['data'].name)
           axios.post('api/user_levels', { level: 1, total_experience_point: 0, 
                                           user_id: localStorage.getItem('user_id') 
-                                        }).then((response) => {
+          }).then((response) => {
           }, (error) => {
             console.log(error)
           })
@@ -132,9 +132,7 @@
           return response
         }, (error) => {
           console.log(error)
-          if (error.response.status == 422) {
-            this.signUpValidateMessage = "登録に失敗しました。もう一度試してください"
-          }
+          this.signUpValidateMessage = "登録に失敗しました。もう一度試してください"
         })
       }
     }

--- a/app/javascript/packs/plugins/vue-axios.js
+++ b/app/javascript/packs/plugins/vue-axios.js
@@ -1,9 +1,20 @@
 const VueAxiosPlugin = {}
 export default VueAxiosPlugin.install = function(Vue, { axios }) {
   const csrf_token = document.querySelector('meta[name="csrf-token"]').getAttribute('content')
-  axios.defaults.headers.common = {
-    "X-Requested-With": "XMLHttpRequest",
-    "X-CSRF-Token": csrf_token
+  
+  if (localStorage.getItem('access-token')) {
+    axios.defaults.headers.common = {
+      "X-Requested-With": "XMLHttpRequest",
+      "X-CSRF-Token": csrf_token,
+      "access-token": localStorage.getItem('access-token'),
+      "uid": localStorage.getItem('uid'),
+      "client": localStorage.getItem('client')
+    }
+  } else {
+    axios.defaults.headers.common = {
+      "X-Requested-With": "XMLHttpRequest",
+      "X-CSRF-Token": csrf_token
+    }
   }
 
   Vue.axios = axios


### PR DESCRIPTION
Closes #183 

- リクエスト時に自動でaccess-tokne,uid,clientを乗せるように実装
  - plugin/vue-axios.jsでローカルストレージにaccess-tokenを保持している場合にaccess-token,uid,clientをheadersに追加するように実装
 
- リクエスト時に追加していたheadersを削除
  - ActionRecordsReferences.vue
  - ActionRecordsRegistration.vue
  - TaskIndex.vue
  - TaskNew.vue
  - TaskEdit.vue