### PR TITLE
nginx.conffを修正

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,19 +1,15 @@
-# プロキシ先の指定
-# Nginxが受け取ったリクエストをバックエンドのpumaに送信
 upstream webapp {
-  # ソケット通信したいのでpuma.sockを指定
   server unix:///webapp/tmp/sockets/puma.sock;
 }
 
 server {
   listen 80;
-  # ドメインもしくはIPを指定
-  server_name example.com [or 192.168.xx.xx [or localhost]];
+  # server_name example.com [or 192.168.xx.xx [or localhost]];
+  server_name localhost 127.0.0.1;
 
   access_log /var/log/nginx/access.log;
   error_log  /var/log/nginx/error.log;
 
-  # ドキュメントルートの指定
   root /webapp/public;
 
   client_max_body_size 100m;
@@ -22,7 +18,6 @@ server {
   try_files  $uri/index.html $uri @webapp;
   keepalive_timeout 5;
 
-  # リバースプロキシ関連の設定
   location @webapp {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Closes #186 

- nginx.conffを修正
  - 余計なコメントを削除
  - server_nameをパスで指定するように修正