### PR TITLE
heroku環境で発生している不具合を修正

### DIFF
--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -4,6 +4,8 @@ class Api::ActionRecordsController < ApplicationController
 
   def index
     @action_records = current_user.action_records
+    puts "-----"
+    puts "index"
   end
 
   def create

--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -10,6 +10,7 @@ class Api::ActionRecordsController < ApplicationController
     action_record = ActionRecord.new(action_record_params)
     @levelup_data = levelUpAndDown(action_record_params[:task_id], action_record_params[:action_day], action_record_params[:action])
     if action_record.save
+      @levelup_data.store(:action_record_id, action_record.id)
       render :registration, status: :ok
     else
       render json: { errors: action_record.errors.keys.map { |key| [key, action_record.errors.full_messages_for(key)] }.to_h, render: "show.json.jbuilder" }, status: :unprocessable_entity
@@ -20,6 +21,7 @@ class Api::ActionRecordsController < ApplicationController
     action_record = ActionRecord.find(action_record_params[:id])
     @levelup_data = levelUpAndDown(action_record_params[:task_id], action_record_params[:action_day], action_record_params[:action])
     if action_record.update(action_record_params)
+      @levelup_data.store(:action_record_id, action_record.id)
       render :registration, status: :ok
     else
       render json: { errors: action_record.errors.keys.map { |key| [key, action_record.errors.full_messages_for(key)] }.to_h, render: "show.json.jbuilder" }, status: :unprocessable_entity

--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -4,8 +4,6 @@ class Api::ActionRecordsController < ApplicationController
 
   def index
     @action_records = current_user.action_records
-    puts "-----"
-    puts "index"
   end
 
   def create

--- a/app/javascript/packs/components/ActionRecordsRegistration.vue
+++ b/app/javascript/packs/components/ActionRecordsRegistration.vue
@@ -176,6 +176,7 @@
       },
       searchAction: function () {
         this.action = ''
+        this.updateFlg = false
 
         for (var i = 0; i < this.ActionRecords.length; i++) {
           if (this.ActionRecords[i].action_day == this.ActionDay
@@ -197,6 +198,7 @@
           this.updateActionRecord()
         } else {
           this.createActionRecord()
+          this.updateFlg = true
         }
       },
       createActionRecord: function () {

--- a/app/javascript/packs/components/ActionRecordsRegistration.vue
+++ b/app/javascript/packs/components/ActionRecordsRegistration.vue
@@ -214,7 +214,6 @@
           this.after_level = response.data.level_up_data['after_level']
           this.state = response.data.level_up_data['before_experience_point_percent']
           this.endState = response.data.level_up_data['after_experience_point_percent']
-          console.log('id: ' + this.actionRecordId)
 
           this.updateLevel()
           this.fetchActionRecord()

--- a/app/javascript/packs/components/ActionRecordsRegistration.vue
+++ b/app/javascript/packs/components/ActionRecordsRegistration.vue
@@ -210,6 +210,7 @@
         ).then((response) => {
           this.actionRecordSuccessMessage = '行動を記録しました'
           this.actionRecordValidateMessage = ''
+          this.actionRecordId = response.data.level_up_data['action_record_id']
           this.before_level = response.data.level_up_data['before_level']
           this.after_level = response.data.level_up_data['after_level']
           this.state = response.data.level_up_data['before_experience_point_percent']

--- a/app/javascript/packs/components/ActionRecordsRegistration.vue
+++ b/app/javascript/packs/components/ActionRecordsRegistration.vue
@@ -200,7 +200,6 @@
           this.createActionRecord()
           this.updateFlg = true
         }
-        this.fetchActionRecord()
       },
       createActionRecord: function () {
         axios.post('/api/action_records', 
@@ -215,8 +214,10 @@
           this.after_level = response.data.level_up_data['after_level']
           this.state = response.data.level_up_data['before_experience_point_percent']
           this.endState = response.data.level_up_data['after_experience_point_percent']
+          console.log('id: ' + this.actionRecordId)
 
           this.updateLevel()
+          this.fetchActionRecord()
         }, (error) => {
           console.log(error)
           this.actionRecordSuccessMessage = ''
@@ -245,6 +246,7 @@
           this.endState = response.data.level_up_data['after_experience_point_percent']
 
           this.updateLevel()
+          this.fetchActionRecord()
         }, (error) => {
           console.log(error)
           this.actionRecordSuccessMessage = ''

--- a/app/javascript/packs/components/ActionRecordsRegistration.vue
+++ b/app/javascript/packs/components/ActionRecordsRegistration.vue
@@ -96,9 +96,9 @@
       }
     },
     mounted: function () {
-      this.getToday();
-      this.fetchTasks();
-      this.fetchActionRecord();
+      this.getToday()
+      this.fetchTasks()
+      this.fetchActionRecord()
     },
     computed: {
       validation: function () {
@@ -131,22 +131,22 @@
     },
     methods: {
       getToday: function () {
-        var today = new Date();
-        today.setDate(today.getDate());
-        var yyyy = today.getFullYear();
-        var mm = ("0" + (today.getMonth() + 1)).slice(-2);
-        var dd = ("0" + today.getDate()).slice(-2);
-        this.ActionDay = yyyy + '-' + mm+'-' + dd;
+        var today = new Date()
+        today.setDate(today.getDate())
+        var yyyy = today.getFullYear()
+        var mm = ("0" + (today.getMonth() + 1)).slice(-2)
+        var dd = ("0" + today.getDate()).slice(-2)
+        this.ActionDay = yyyy + '-' + mm+'-' + dd
       },
       fetchTasks: function () {
         axios.get('/api/tasks', 
                   { headers: this.headers }
         ).then((response) => {
           for(var i = 0; i < response.data.tasks.length; i++) {
-            this.tasks.push(response.data.tasks[i]);
+            this.tasks.push(response.data.tasks[i])
           }
         }, (error) => {
-          console.log(error);
+          console.log(error)
         });
       },
       fetchActionRecord: function () {
@@ -154,15 +154,15 @@
                   { headers: this.headers }
         ).then((response) => {
           for(var i = 0; i < response.data.action_records.length; i++) {
-            this.ActionRecords.push(response.data.action_records[i]);
+            this.ActionRecords.push(response.data.action_records[i])
           }
         }, (error) => {
-          console.log(error);
+          console.log(error)
         })
       },
       chengeDate: function () {
         if (this.selectTask) {
-          this.searchAction();
+          this.searchAction()
         }
       },
       chengeTask: function () {
@@ -172,7 +172,7 @@
             this.unit = this.tasks[i].unit
           }
         }
-        this.searchAction();
+        this.searchAction()
       },
       searchAction: function () {
         this.action = ''
@@ -192,7 +192,7 @@
         this.action_experience_point = (Math.round(this.action * 100) / 100) / (Math.round(this.goal * 100) / 100) * 100
       },
       registerActionRecord: function () {
-        this.culculateActionExperiencePoint();
+        this.culculateActionExperiencePoint()
 
         if (this.updateFlg) {
           this.updateActionRecord()
@@ -200,6 +200,7 @@
           this.createActionRecord()
           this.updateFlg = true
         }
+        this.fetchActionRecord()
       },
       createActionRecord: function () {
         axios.post('/api/action_records', 
@@ -284,7 +285,7 @@
         }
 
         if (this.state == this.endState) {
-          clearInterval(this.intervalId);
+          clearInterval(this.intervalId)
         }
       },
       updateProgressLevelUp: function () {

--- a/app/javascript/packs/components/NaviBar.vue
+++ b/app/javascript/packs/components/NaviBar.vue
@@ -56,7 +56,7 @@
           localStorage.setItem('user_id', response.data['data'].id)
           localStorage.setItem('email', response.data['data'].email)
           localStorage.setItem('name', response.data['data'].name)
-          location.href = "http://localhost:3000/mypage"
+          location.href = "/mypage"
           return response
         }, (error) => {
           console.log(error)
@@ -74,7 +74,7 @@
                     { headers: this.headers } 
         ).then((response) => {
             localStorage.clear()
-            location.href = "http://localhost:3000/"
+            location.href = "/"
         }, (error) => {
           console.log(error)
         })

--- a/app/javascript/packs/components/TaskNew.vue
+++ b/app/javascript/packs/components/TaskNew.vue
@@ -90,7 +90,6 @@ export default {
                 { task: { task: this.task, goal: this.goal, unit: this.unit, user_id: localStorage.getItem('user_id') } }, 
                 { headers: this.headers }
       ).then((response) => {
-        alert('新規登録しました。')
         this.taskValidateMessage = ''
         this.taskNewSuccessMessage = '習慣を新規登録しました'
       }, (error) => {

--- a/app/javascript/packs/components/UserLogin.vue
+++ b/app/javascript/packs/components/UserLogin.vue
@@ -87,7 +87,7 @@
           localStorage.setItem('user_id', response.data['data'].id)
           localStorage.setItem('email', response.data['data'].email)
           localStorage.setItem('name', response.data['data'].name)
-          location.href = "http://localhost:3000/mypage"
+          llocation.href = "/mypage"
           return response
         }, (error) => {
           console.log(error)

--- a/app/javascript/packs/components/UserSignUp.vue
+++ b/app/javascript/packs/components/UserSignUp.vue
@@ -128,7 +128,7 @@
           }, (error) => {
             console.log(error)
           })
-          location.href = "http://localhost:3000/mypage"
+          location.href = "/mypage"
           return response
         }, (error) => {
           console.log(error)

--- a/app/views/api/action_records/registration.json.jbuilder
+++ b/app/views/api/action_records/registration.json.jbuilder
@@ -1,5 +1,5 @@
 json.set! :level_up_data do
-  json.extract! @levelup_data, :before_level, :after_level,
+  json.extract! @levelup_data, :action_record_id, :before_level, :after_level,
                 :before_experience_point_percent,
                 :after_experience_point_percent
 end


### PR DESCRIPTION
Closes #203 

- 行動記録を登録後にそのまま実績を修正し登録すると、新規登録をしようとしてエラーが発生する不具合を修正
  - updateFlgの処理を修正
- 行動記録を登録後にDBからActionRecordsを取得するように修正
- 行動記録登録時のレスポンスのjsonにaction_recordsのidを追加。新規登録時に登録したaction_recordのidを取得
  - create、updateアクションで登録成功時に使用するjsonデータにaction_recordのidを追加
- ログイン、新規登録、ログアウト時のリダイレクト処理を修正
  - 相対パスに修正