### PR TITLE
行動記録を登録後にレベル処理を行うように修正 #206

### DIFF
--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -8,9 +8,11 @@ class Api::ActionRecordsController < ApplicationController
 
   def create
     action_record = ActionRecord.new(action_record_params)
-    @levelup_data = levelUpAndDown(action_record_params[:task_id], action_record_params[:action_day], action_record_params[:action])
+
     if action_record.save
+      @levelup_data = levelUpAndDown(action_record_params[:task_id], action_record_params[:action_day], action_record_params[:action], true, nil)
       @levelup_data.store(:action_record_id, action_record.id)
+
       render :registration, status: :ok
     else
       render json: { errors: action_record.errors.keys.map { |key| [key, action_record.errors.full_messages_for(key)] }.to_h, render: "show.json.jbuilder" }, status: :unprocessable_entity
@@ -19,9 +21,13 @@ class Api::ActionRecordsController < ApplicationController
 
   def update
     action_record = ActionRecord.find(action_record_params[:id])
-    @levelup_data = levelUpAndDown(action_record_params[:task_id], action_record_params[:action_day], action_record_params[:action])
+    # 修正前のDBに登録されているActionRecordのactionを取得
+    before_action = ActionRecord.getAction(action_record_params[:action_day], action_record_params[:user_id], action_record_params[:task_id])
+
     if action_record.update(action_record_params)
+      @levelup_data = levelUpAndDown(action_record_params[:task_id], action_record_params[:action_day], action_record_params[:action], false, before_action)
       @levelup_data.store(:action_record_id, action_record.id)
+
       render :registration, status: :ok
     else
       render json: { errors: action_record.errors.keys.map { |key| [key, action_record.errors.full_messages_for(key)] }.to_h, render: "show.json.jbuilder" }, status: :unprocessable_entity

--- a/app/controllers/api/action_records_controller.rb
+++ b/app/controllers/api/action_records_controller.rb
@@ -21,7 +21,7 @@ class Api::ActionRecordsController < ApplicationController
 
   def update
     action_record = ActionRecord.find(action_record_params[:id])
-    # 修正前のDBに登録されているActionRecordのactionを取得
+    # 修正前のDBに登録されているactionを取得
     before_action = ActionRecord.getAction(action_record_params[:action_day], action_record_params[:user_id], action_record_params[:task_id])
 
     if action_record.update(action_record_params)

--- a/app/models/action_record.rb
+++ b/app/models/action_record.rb
@@ -9,6 +9,10 @@ class ActionRecord < ApplicationRecord
 
   PERCENT = 100
 
+  def self.getAction(action_day, task_id, user_id)
+    ActionRecord.find_by(action_day: action_day, task_id: task_id, user_id: user_id).action
+  end
+
   # 実績の経験値を取得
   def self.getActionExperiencePoint(action_day, task_id, user_id)
     ActionRecord.find_by(action_day: action_day, task_id: task_id, user_id: user_id).action_experience_point
@@ -23,10 +27,5 @@ class ActionRecord < ApplicationRecord
   # 引数で指定したタスクの期間の実績を配列で取得
   def self.weekOfActions(task_id, from, to)
     ActionRecord.where(task_id: task_id).where(action_day: from...to).select(:action).pluck(:action)
-  end
-
-  # 既にデータが存在するかチェックする
-  def self.getActionRecord(action_day, task_id, user_id)
-    ActionRecord.find_by(action_day: action_day, task_id: task_id, user_id: user_id)
   end
 end

--- a/app/models/action_record.rb
+++ b/app/models/action_record.rb
@@ -13,12 +13,10 @@ class ActionRecord < ApplicationRecord
     ActionRecord.find_by(action_day: action_day, task_id: task_id, user_id: user_id).action
   end
 
-  # 実績の経験値を取得
   def self.getActionExperiencePoint(action_day, task_id, user_id)
     ActionRecord.find_by(action_day: action_day, task_id: task_id, user_id: user_id).action_experience_point
   end
 
-  # 実績の経験値を登録
   def self.uploadActionExperiencePoint(action_day, task_id, user_id, action_experience_point)
     action_record = ActionRecord.find_by(action_day: action_day, task_id: task_id, user_id: user_id)
     action_record.update_attribute("action_experience_point", action_experience_point)

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -1,6 +1,5 @@
 class Level < ApplicationRecord
 
-  # 指定したレベルの必要経験値を取得
   def self.getRequreidExperiecePoint(level)
     Level.find_by(level: level).required_experience_point
   end

--- a/app/models/user_level.rb
+++ b/app/models/user_level.rb
@@ -4,23 +4,18 @@ class UserLevel < ApplicationRecord
   validates :level, presence: true
   validates :total_experience_point, presence: true
 
-  # ユーザのレベルを取得
   def self.getUserLevel(user_id)
     UserLevel.find_by(user_id: user_id).level
   end
-
-  # ユーザの総経験値を取得
   def self.getTotalExperiencePoint(user_id)
     UserLevel.find_by(user_id: user_id).total_experience_point
   end
 
-  # ユーザのレベルを登録
   def self.uploadUserLevel(user_id, level)
     user = UserLevel.find_by(user_id: user_id)
     user.update_attribute("level", level)
   end
 
-  # ユーザの総経験値を登録
   def self.uploadUserTotalExperiencePoint(user_id, total_experience_point)
     user = UserLevel.find_by(user_id: user_id)
     user.update_attribute("total_experience_point", total_experience_point)


### PR DESCRIPTION
Closes #206 

- 行動記録を登録後にレベル処理を行うように修正
  - action_records_controller.rbのcreateアクションとupdateアクションでデータ登録後にレベル処理を行うように修正
  - updateアクションでupdateする前にDBに登録されているactionを取得
  - levelUpAndDownメソッドの引数にcreateかupdateを判断するcreate_flgを追加
  - levelUpAndDownメソッドの引数に既に登録されているactionを追加
  - 不要になったメソッドを削除
  - 